### PR TITLE
Refactor `verifyRequest` and `findEmployees`

### DIFF
--- a/app/lib/verify-request.server.ts
+++ b/app/lib/verify-request.server.ts
@@ -47,3 +47,11 @@ export const verifyEmployeeRequest = async (
     throw unauthorizedResponse();
   }
 };
+
+export const verifyCustomerRequest = async (
+  request: Request,
+): Promise<{ id: string }> => {
+  return {
+    id: "",
+  };
+};

--- a/app/lib/verify-request.server.ts
+++ b/app/lib/verify-request.server.ts
@@ -5,46 +5,40 @@ import {
   badRequestResponse,
   unauthorizedResponse,
 } from "~/helpers/response-helpers.server";
-
-type Employee = {
-  id: string;
-  role: Role;
-};
-
-type Customer = {
-  id: string;
-};
-
-type ReturnType<T> = T extends "customer"
-  ? Customer
-  : T extends "employee"
-  ? Employee
-  : never;
+import { findEmployee } from "~/models/employee/employee.server";
 
 /**
- * Verify the authenticity of a request's JWT
+ * Verify the authenticity of an employee request's JWT
  * @param request The request to verify
  * @returns The data contained in the JWT
  */
-export const verifyRequest = <UserType extends "customer" | "employee">(
-  request: Request
-): ReturnType<UserType> => {
+export const verifyEmployeeRequest = async (
+  request: Request,
+): Promise<{
+  id: string;
+  role: Role;
+}> => {
   const authorizationHeader = request.headers.get("Authorization");
   if (authorizationHeader) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, jwt] = authorizationHeader.split(" ");
     const decodedJwt = verifyJwt(jwt);
-    let parsedData: z.SafeParseReturnType<any, any>;
     const schema = z.object({
       id: z.string(),
-      role: z.optional(z.nativeEnum(Role)),
+      role: z.nativeEnum(Role),
     });
 
-    parsedData = schema.safeParse(
-      typeof decodedJwt === "string" ? JSON.parse(decodedJwt) : decodedJwt
+    const parsedData = schema.safeParse(
+      typeof decodedJwt === "string" ? JSON.parse(decodedJwt) : decodedJwt,
     );
 
     if (parsedData.success) {
+      const employee = await findEmployee(parsedData.data.id);
+
+      if (employee == null) {
+        throw unauthorizedResponse();
+      }
+
       return parsedData.data;
     } else {
       throw badRequestResponse();

--- a/app/models/dto/index.ts
+++ b/app/models/dto/index.ts
@@ -12,6 +12,16 @@ export type LoginDto = {
   password: string;
 };
 
+export type EmployeeRead = {
+  id: string;
+  email: string;
+  createdAt: Date;
+  updatedAt: Date;
+  firstName: string;
+  lastName: string;
+  role: Role;
+};
+
 export type EmployeeCreateInput = {
   email: string;
   password: string;

--- a/app/models/employee/employee.server.tsx
+++ b/app/models/employee/employee.server.tsx
@@ -2,12 +2,23 @@ import type { Employee, Role } from "@prisma/client";
 import { database } from "~/helpers/db-helper.server";
 import type {
   EmployeeCreateInput,
+  EmployeeRead,
   EmployeeUpdateInput,
   LoginDto,
 } from "../dto";
 
-export const findEmployees = async (): Promise<Employee[]> => {
-  return database.employee.findMany();
+export const findEmployees = async (): Promise<EmployeeRead[]> => {
+  return database.employee.findMany({
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      role: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
 };
 
 export const findEmployeeByLogin = async ({

--- a/app/routes/api/v1/ecommerce/customers/creditCard/index.ts
+++ b/app/routes/api/v1/ecommerce/customers/creditCard/index.ts
@@ -3,7 +3,7 @@ import type { ActionFunction } from "@remix-run/node";
 import { z } from "zod";
 import { methodNotAllowedResponse } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyEmployeeRequest } from "~/lib/verify-request.server";
+import { verifyCustomerRequest } from "~/lib/verify-request.server";
 import { createCustomerCreditCard } from "~/models/customer/customer.server";
 
 export const action: ActionFunction = async ({
@@ -13,7 +13,7 @@ export const action: ActionFunction = async ({
     throw methodNotAllowedResponse();
   }
 
-  let jwtContent = await verifyEmployeeRequest<"customer">(request);
+  let jwtContent = await verifyCustomerRequest(request);
 
   const schema = z.object({
     creditCard: z.object({

--- a/app/routes/api/v1/ecommerce/customers/creditCard/index.ts
+++ b/app/routes/api/v1/ecommerce/customers/creditCard/index.ts
@@ -3,7 +3,7 @@ import type { ActionFunction } from "@remix-run/node";
 import { z } from "zod";
 import { methodNotAllowedResponse } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { createCustomerCreditCard } from "~/models/customer/customer.server";
 
 export const action: ActionFunction = async ({
@@ -13,7 +13,7 @@ export const action: ActionFunction = async ({
     throw methodNotAllowedResponse();
   }
 
-  let jwtContent = verifyRequest<"customer">(request);
+  let jwtContent = await verifyEmployeeRequest<"customer">(request);
 
   const schema = z.object({
     creditCard: z.object({
@@ -27,7 +27,7 @@ export const action: ActionFunction = async ({
   const data = await parseBody(request, schema);
   const customer = await createCustomerCreditCard(
     jwtContent.id,
-    data.creditCard
+    data.creditCard,
   );
   return customer;
 };

--- a/app/routes/api/v1/ecommerce/customers/index.ts
+++ b/app/routes/api/v1/ecommerce/customers/index.ts
@@ -3,7 +3,7 @@ import { json } from "@remix-run/node";
 import { string, z } from "zod";
 import { methodNotAllowedResponse } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import {
   createCustomer,
   deleteCustomer,
@@ -41,7 +41,7 @@ export const postRequest = async (request: Request): Promise<Response> => {
 };
 
 export const patchRequest = async (request: Request): Promise<Response> => {
-  let jwtContent = verifyRequest<"customer">(request);
+  let jwtContent = await verifyEmployeeRequest<"customer">(request);
 
   const schema = z.object({
     customer: z.object({

--- a/app/routes/api/v1/ecommerce/customers/index.ts
+++ b/app/routes/api/v1/ecommerce/customers/index.ts
@@ -3,7 +3,7 @@ import { json } from "@remix-run/node";
 import { string, z } from "zod";
 import { methodNotAllowedResponse } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyEmployeeRequest } from "~/lib/verify-request.server";
+import { verifyCustomerRequest } from "~/lib/verify-request.server";
 import {
   createCustomer,
   deleteCustomer,
@@ -41,7 +41,7 @@ export const postRequest = async (request: Request): Promise<Response> => {
 };
 
 export const patchRequest = async (request: Request): Promise<Response> => {
-  let jwtContent = await verifyEmployeeRequest<"customer">(request);
+  let jwtContent = await verifyCustomerRequest(request);
 
   const schema = z.object({
     customer: z.object({

--- a/app/routes/api/v1/warehouse/activeProducts/$activeProductInstaceId.ts
+++ b/app/routes/api/v1/warehouse/activeProducts/$activeProductInstaceId.ts
@@ -5,7 +5,7 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findActiveProduct } from "~/models/activeProducts/activeProducts.server";
 
 type LoaderData = ActiveProductInstance;
@@ -16,7 +16,7 @@ export const loader: LoaderFunction = async ({
 }): Promise<LoaderData> => {
   const activeProductInstanceId = params.productInstanceId;
 
-  let jwtContent = verifyRequest<"employee">(request);
+  let jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN") {
     throw forbiddenResponse();
   }

--- a/app/routes/api/v1/warehouse/activeProducts/index.ts
+++ b/app/routes/api/v1/warehouse/activeProducts/index.ts
@@ -7,7 +7,7 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import {
   createActiveProduct,
   deleteActiveProduct,
@@ -23,7 +23,7 @@ export const loader: LoaderFunction = async ({
     return methodNotAllowedResponse();
   }
 
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
 
   const activeProducts = await findActiveProducts();
   return okResponse(JSON.stringify({ activeProducts }));
@@ -41,7 +41,7 @@ export const action: ActionFunction = async ({
   const method = request.method.toLowerCase();
 
   if (method in map) {
-    let jwtContent = verifyRequest<"employee">(request);
+    let jwtContent = await verifyEmployeeRequest(request);
     if (jwtContent.role !== "ADMIN") {
       throw forbiddenResponse();
     }

--- a/app/routes/api/v1/warehouse/customers/$customerId/activeProducts.ts
+++ b/app/routes/api/v1/warehouse/customers/$customerId/activeProducts.ts
@@ -4,7 +4,7 @@ import {
   notFoundResponse,
   okResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findCustomerActiveProducts } from "~/models/customer/customer.server";
 
 export const loader: LoaderFunction = async ({
@@ -17,7 +17,7 @@ export const loader: LoaderFunction = async ({
     return badRequestResponse();
   }
 
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
 
   const customerId = params.customerId;
   if (!customerId) {

--- a/app/routes/api/v1/warehouse/customers/$customerId/index.ts
+++ b/app/routes/api/v1/warehouse/customers/$customerId/index.ts
@@ -5,7 +5,7 @@ import {
   notFoundResponse,
   okResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import {
   deleteCustomer,
   findCustomer,
@@ -19,7 +19,7 @@ export const loader: LoaderFunction = async ({
     return methodNotAllowedResponse();
   }
 
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
 
   const customerId = params.customerId;
   if (!customerId) {
@@ -41,7 +41,7 @@ export const action: ActionFunction = async ({
 }): Promise<Response> => {
   switch (request.method.toLowerCase()) {
     case "delete": {
-      verifyRequest<"employee">(request);
+      await verifyEmployeeRequest(request);
       const customerId = params.customerId;
       if (!customerId) {
         return badRequestResponse();

--- a/app/routes/api/v1/warehouse/customers/$customerId/orders.ts
+++ b/app/routes/api/v1/warehouse/customers/$customerId/orders.ts
@@ -4,7 +4,7 @@ import {
   badRequestResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findCustomerOrders } from "~/models/order/order.server";
 
 type LoaderData = { orders: Order[] };
@@ -19,7 +19,7 @@ export const loader: LoaderFunction = async ({
     throw badRequestResponse();
   }
 
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
 
   const orders = await findCustomerOrders(customerId);
 

--- a/app/routes/api/v1/warehouse/customers/index.ts
+++ b/app/routes/api/v1/warehouse/customers/index.ts
@@ -1,12 +1,12 @@
 import { LoaderFunction } from "@remix-run/node";
 import { okResponse } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findCustomers } from "~/models/customer/customer.server";
 
 export const loader: LoaderFunction = async ({
   request,
 }): Promise<Response> => {
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
   const customers = await findCustomers();
   return okResponse(JSON.stringify({ customers }));
 };

--- a/app/routes/api/v1/warehouse/employees/$employeeId/index.ts
+++ b/app/routes/api/v1/warehouse/employees/$employeeId/index.ts
@@ -9,7 +9,7 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import {
   deleteEmployee,
   findEmployee,
@@ -24,7 +24,7 @@ export const loader: LoaderFunction = async ({
     throw methodNotAllowedResponse();
   }
 
-  verifyRequest<"employee">(request);
+  verifyEmployeeRequest<"employee">(request);
 
   const employeeId = params.employeeId;
   if (!employeeId) {
@@ -47,7 +47,7 @@ export const action: ActionFunction = async ({
   const method = request.method.toLowerCase();
 
   if (method === "patch" || method === "delete") {
-    const jwtContent = verifyRequest<"employee">(request);
+    const jwtContent = verifyEmployeeRequest<"employee">(request);
     if (method === "patch") {
       if (jwtContent.role !== "ADMIN") {
         throw forbiddenResponse();

--- a/app/routes/api/v1/warehouse/employees/index.ts
+++ b/app/routes/api/v1/warehouse/employees/index.ts
@@ -20,7 +20,9 @@ export const loader: LoaderFunction = async ({
   if (jwtContent.role !== "ADMIN") {
     throw forbiddenResponse();
   }
-  const employees = await findEmployees();
+  const employees = (await findEmployees()).filter(
+    (el) => el.id !== jwtContent.id,
+  );
   return okResponse(JSON.stringify({ employees }));
 };
 

--- a/app/routes/api/v1/warehouse/employees/index.ts
+++ b/app/routes/api/v1/warehouse/employees/index.ts
@@ -7,7 +7,7 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import {
   createEmployee,
   findEmployees,
@@ -16,7 +16,7 @@ import {
 export const loader: LoaderFunction = async ({
   request,
 }): Promise<Response> => {
-  let jwtContent = verifyRequest<"employee">(request);
+  let jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN") {
     throw forbiddenResponse();
   }
@@ -30,7 +30,7 @@ export const action: ActionFunction = async ({
   if (request.method.toLowerCase() !== "post") {
     throw methodNotAllowedResponse();
   }
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
 
   const schema = z.object({
     email: z.string(),

--- a/app/routes/api/v1/warehouse/employees/me.ts
+++ b/app/routes/api/v1/warehouse/employees/me.ts
@@ -1,0 +1,16 @@
+import { LoaderFunction } from "@remix-run/node";
+import {
+  forbiddenResponse,
+  okResponse,
+} from "~/helpers/response-helpers.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
+import { findEmployee } from "~/models/employee/employee.server";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const jwtContent = await verifyEmployeeRequest(request);
+  if (jwtContent.role !== "ADMIN") {
+    throw forbiddenResponse();
+  }
+  const employee = await findEmployee(jwtContent.id);
+  return okResponse(JSON.stringify(employee));
+};

--- a/app/routes/api/v1/warehouse/orders/$orderId.ts
+++ b/app/routes/api/v1/warehouse/orders/$orderId.ts
@@ -4,7 +4,7 @@ import {
   badRequestResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findOrderById } from "~/models/order/order.server";
 
 type LoaderData = { order: Order };
@@ -13,7 +13,7 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<LoaderData> => {
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
   const orderId = params.orderId;
 
   if (!orderId) {

--- a/app/routes/api/v1/warehouse/orders/by-id/index.ts
+++ b/app/routes/api/v1/warehouse/orders/by-id/index.ts
@@ -8,7 +8,7 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { deleteOrder, updateOrder } from "~/models/order/order.server";
 
 export const action: ActionFunction = async ({
@@ -30,7 +30,7 @@ export const action: ActionFunction = async ({
 };
 
 const handlePATCHRequest = async (request: Request): Promise<Response> => {
-  const jwtContent = verifyRequest<"employee">(request);
+  const jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN" || "WORKER") {
     throw forbiddenResponse();
   }
@@ -60,7 +60,7 @@ const handlePATCHRequest = async (request: Request): Promise<Response> => {
 };
 
 const handleDELETERequest = async (request: Request): Promise<Response> => {
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
 
   const schema = z.object({
     id: z.string().cuid(),

--- a/app/routes/api/v1/warehouse/orders/by-status/$status.ts
+++ b/app/routes/api/v1/warehouse/orders/by-status/$status.ts
@@ -7,7 +7,7 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findOrdersByStatus } from "~/models/order/order.server";
 
 type LoaderData = { orders: Order[] };
@@ -16,7 +16,7 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<LoaderData> => {
-  const jwtContent = verifyRequest<"employee">(request);
+  const jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN" || "WORKER") {
     throw forbiddenResponse();
   }

--- a/app/routes/api/v1/warehouse/orders/dates/within-delivered/index.ts
+++ b/app/routes/api/v1/warehouse/orders/dates/within-delivered/index.ts
@@ -7,7 +7,7 @@ import {
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findOrdersWithinDeliveredDates } from "~/models/order/order.server";
 
 type LoaderData = {
@@ -20,7 +20,7 @@ export const action: ActionFunction = async ({
   if (request.method.toLowerCase() != "post") {
     throw methodNotAllowedResponse();
   }
-  const jwtContent = verifyRequest<"employee">(request);
+  const jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN" || "WORKER") {
     throw forbiddenResponse();
   }
@@ -42,7 +42,7 @@ export const action: ActionFunction = async ({
 
   const ordersWithinDates = await findOrdersWithinDeliveredDates(
     parsedData.startDate,
-    parsedData.endDate
+    parsedData.endDate,
   );
 
   if (!ordersWithinDates || !ordersWithinDates.length) {

--- a/app/routes/api/v1/warehouse/orders/dates/within-ordered/index.ts
+++ b/app/routes/api/v1/warehouse/orders/dates/within-ordered/index.ts
@@ -7,7 +7,7 @@ import {
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findOrdersWithinOrderedDates } from "~/models/order/order.server";
 
 type LoaderData = {
@@ -20,7 +20,7 @@ export const action: ActionFunction = async ({
   if (request.method.toLowerCase() != "post") {
     throw methodNotAllowedResponse();
   }
-  const jwtContent = verifyRequest<"employee">(request);
+  const jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN" || "WORKER") {
     throw forbiddenResponse();
   }
@@ -42,7 +42,7 @@ export const action: ActionFunction = async ({
 
   const ordersWithinDates = await findOrdersWithinOrderedDates(
     parsedData.startDate,
-    parsedData.endDate
+    parsedData.endDate,
   );
 
   if (!ordersWithinDates || !ordersWithinDates.length) {

--- a/app/routes/api/v1/warehouse/orders/dates/within-shipped/index.ts
+++ b/app/routes/api/v1/warehouse/orders/dates/within-shipped/index.ts
@@ -7,7 +7,7 @@ import {
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findOrdersWithinShippedDates } from "~/models/order/order.server";
 
 type LoaderData = {
@@ -20,7 +20,7 @@ export const action: ActionFunction = async ({
   if (request.method.toLowerCase() != "post") {
     throw methodNotAllowedResponse();
   }
-  const jwtContent = verifyRequest<"employee">(request);
+  const jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN" || "WORKER") {
     throw forbiddenResponse();
   }
@@ -42,7 +42,7 @@ export const action: ActionFunction = async ({
 
   const ordersWithinDates = await findOrdersWithinShippedDates(
     parsedData.startDate,
-    parsedData.endDate
+    parsedData.endDate,
   );
 
   if (!ordersWithinDates || !ordersWithinDates.length) {

--- a/app/routes/api/v1/warehouse/orders/index.ts
+++ b/app/routes/api/v1/warehouse/orders/index.ts
@@ -9,7 +9,7 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { createOrder, findOrders } from "~/models/order/order.server";
 import {
   findManyProductInstancesAvailableToOrder,
@@ -21,7 +21,7 @@ type LoaderData = { orders: Order[] };
 export const loader: LoaderFunction = async ({
   request,
 }): Promise<LoaderData> => {
-  const jwtContent = verifyRequest<"employee">(request);
+  const jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN" || "WORKER") {
     throw forbiddenResponse();
   }
@@ -36,7 +36,7 @@ export const action: ActionFunction = async ({
 }): Promise<Response> => {
   switch (request.method.toLowerCase()) {
     case "post": {
-      verifyRequest<"customer">(request);
+      verifyEmployeeRequest(request);
       return handlePOSTRequest(request);
     }
 
@@ -66,7 +66,7 @@ const handlePOSTRequest = async (request: Request): Promise<Response> => {
   for (var product of parsedData.products) {
     const queryResult = await findManyProductInstancesAvailableToOrder(
       product.productId,
-      product.quantity
+      product.quantity,
     );
 
     if (!queryResult) {

--- a/app/routes/api/v1/warehouse/productInstances/$productInstanceId.ts
+++ b/app/routes/api/v1/warehouse/productInstances/$productInstanceId.ts
@@ -4,7 +4,7 @@ import {
   badRequestResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { findProductInstance } from "~/models/productInstance/productInstance.server";
 
 type LoaderData = ProductInstance;
@@ -13,7 +13,7 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<LoaderData> => {
-  verifyRequest<"customer">(request);
+  await verifyEmployeeRequest(request);
 
   const productInstanceId = params.productInstanceId;
 

--- a/app/routes/api/v1/warehouse/productInstances/count/by-status/$productInstanceStatus.ts
+++ b/app/routes/api/v1/warehouse/productInstances/count/by-status/$productInstanceStatus.ts
@@ -6,7 +6,7 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { countProductInstancesByStatus } from "~/models/productInstance/productInstance.server";
 
 type LoaderData = {
@@ -17,7 +17,7 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<LoaderData> => {
-  let jwtContent = verifyRequest<"employee">(request);
+  let jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN") {
     throw forbiddenResponse();
   }
@@ -32,7 +32,7 @@ export const loader: LoaderFunction = async ({
   const parsedData = schema.safeParse(productInstanceStatus);
   if (parsedData.success) {
     const countedProductInstancesStatus = await countProductInstancesByStatus(
-      parsedData.data
+      parsedData.data,
     );
 
     if (countedProductInstancesStatus == null) {

--- a/app/routes/api/v1/warehouse/productInstances/count/by-type/$productId.ts
+++ b/app/routes/api/v1/warehouse/productInstances/count/by-type/$productId.ts
@@ -4,7 +4,7 @@ import {
   forbiddenResponse,
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { countProductInstancesByType } from "~/models/productInstance/productInstance.server";
 
 type LoaderData = {
@@ -15,7 +15,7 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<LoaderData> => {
-  let jwtContent = verifyRequest<"employee">(request);
+  let jwtContent = await verifyEmployeeRequest(request);
   if (jwtContent.role !== "ADMIN") {
     throw forbiddenResponse();
   }

--- a/app/routes/api/v1/warehouse/productInstances/index.ts
+++ b/app/routes/api/v1/warehouse/productInstances/index.ts
@@ -8,7 +8,7 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import type { ProductInstances } from "~/models/dto";
 import {
   createManyProductInstances,
@@ -24,7 +24,7 @@ type LoaderData = {
 export const loader: LoaderFunction = async ({
   request,
 }): Promise<LoaderData> => {
-  verifyRequest<"employee">(request);
+  await verifyEmployeeRequest(request);
   const productInstances = await findManyProductInstances();
   return {
     productInstances,
@@ -43,7 +43,7 @@ export const action: ActionFunction = async ({
   const method = request.method.toLowerCase();
 
   if (method in map) {
-    let jwtContent = verifyRequest<"employee">(request);
+    let jwtContent = await verifyEmployeeRequest(request);
     if (method !== "patch") {
       if (jwtContent.role !== "ADMIN") {
         throw forbiddenResponse();
@@ -65,11 +65,11 @@ const postRequest = async (request: Request): Promise<Response> => {
 
   const createdProductInstances = await createManyProductInstances(
     data.productId,
-    data.quantity
+    data.quantity,
   );
 
   return okResponse(
-    JSON.stringify({ numberOfCreatedProducts: createdProductInstances })
+    JSON.stringify({ numberOfCreatedProducts: createdProductInstances }),
   );
 };
 

--- a/app/routes/api/v1/warehouse/productInstances/productInstanceActivation.ts
+++ b/app/routes/api/v1/warehouse/productInstances/productInstanceActivation.ts
@@ -6,7 +6,7 @@ import {
   notFoundResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { productInstanceActivation } from "~/models/productInstance/productInstance.server";
 
 type ActionData = {
@@ -20,7 +20,7 @@ export const action: ActionFunction = async ({
     throw methodNotAllowedResponse();
   }
 
-  verifyRequest<"customer">(request);
+  await verifyEmployeeRequest(request);
 
   const schema = z.object({
     customerId: z.string().cuid(),
@@ -30,7 +30,7 @@ export const action: ActionFunction = async ({
   const data = await parseBody(request, schema);
   const productInstanceActivated = await productInstanceActivation(
     data.customerId,
-    data.productInstanceId
+    data.productInstanceId,
   );
 
   if (productInstanceActivated == null) {

--- a/app/routes/api/v1/warehouse/products/$productId.ts
+++ b/app/routes/api/v1/warehouse/products/$productId.ts
@@ -9,7 +9,7 @@ import {
 } from "~/helpers/response-helpers.server";
 
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import {
   deleteProduct,
   findProduct,
@@ -20,7 +20,7 @@ export const loader: LoaderFunction = async ({
   request,
   params,
 }): Promise<Response> => {
-  verifyRequest<"customer">(request);
+  verifyEmployeeRequest(request);
 
   const productId = params.productId;
 
@@ -43,7 +43,7 @@ export const action: ActionFunction = async ({
 }): Promise<Response> => {
   const method = request.method.toLowerCase();
   if (method === "patch" || method === "delete") {
-    const jwtContent = verifyRequest<"employee">(request);
+    const jwtContent = await verifyEmployeeRequest(request);
     if (jwtContent.role !== "ADMIN") {
       throw forbiddenResponse();
     }

--- a/app/routes/api/v1/warehouse/products/index.ts
+++ b/app/routes/api/v1/warehouse/products/index.ts
@@ -6,13 +6,13 @@ import {
   okResponse,
 } from "~/helpers/response-helpers.server";
 import { parseBody } from "~/lib/parse-body.server";
-import { verifyRequest } from "~/lib/verify-request.server";
+import { verifyEmployeeRequest } from "~/lib/verify-request.server";
 import { createProduct, findProducts } from "~/models/product/product.server";
 
 export const loader: LoaderFunction = async ({
   request,
 }): Promise<Response> => {
-  verifyRequest<"employee">(request);
+  verifyEmployeeRequest(request);
 
   const products = await findProducts();
   return okResponse(JSON.stringify({ products }));
@@ -23,7 +23,7 @@ export const action: ActionFunction = async ({
 }): Promise<Response> => {
   switch (request.method.toLowerCase()) {
     case "post": {
-      const jwtContent = verifyRequest<"employee">(request);
+      const jwtContent = await verifyEmployeeRequest(request);
       if (jwtContent.role !== "ADMIN") {
         throw forbiddenResponse();
       }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,14 +7,14 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - "database:/var/lib/postgresql/data"
+      - "pw_database:/var/lib/postgresql/data"
     env_file:
       - .env
-  backend:
-    build: ./
-    container_name: backend
-    ports:
-      - "3000:3000"
+  # backend:
+  #   build: ./
+  #   container_name: backend
+  #   ports:
+  #     - "3000:3000"
 
 volumes:
-  database:
+  pw_database:


### PR DESCRIPTION
## Changelog

This PR refactor the `verifyRequest` function, that will be an async from now, will be named `verifyEmployeeRequest` and will just check for the `Employees` requests.

In order to check the `Customers` requests a new function is needed.

This is why there are a lot of file changed.

The `findEmployees` function has been updated to not return the hashed password.